### PR TITLE
Fix passing of a custom oe_build_env to detect

### DIFF
--- a/bd_scan_yocto/bd_scan_process.py
+++ b/bd_scan_yocto/bd_scan_process.py
@@ -89,7 +89,7 @@ def run_detect_for_bitbake():
                   f"--detect.project.version.name='{global_values.bd_version}' "
     detect_cmd += f"--blackduck.url={global_values.bd_url} "
     detect_cmd += f"--blackduck.api.token={global_values.bd_api} "
-    detect_cmd += f"--detect.bitbake.build.env.name='{global_values.oe_build_env}' "
+    detect_cmd += f"--detect.bitbake.build.env.name='{global_values.oe_build_envfile}' "
     detect_cmd += f"--detect.source.path='{global_values.oe_build_envpath}' "
     if global_values.bd_trustcert:
         detect_cmd += "--blackduck.trust.cert=true "

--- a/bd_scan_yocto/config.py
+++ b/bd_scan_yocto/config.py
@@ -112,10 +112,10 @@ def check_args():
     logging.info('----------------------------------   PHASE 0  ----------------------------------')
 
     if args.oe_build_env != '':
+        global_values.oe_build_env = args.oe_build_env
+        global_values.oe_build_envfile = os.path.basename(args.oe_build_env)
         if os.path.dirname(args.oe_build_env) != '':
             global_values.oe_build_envpath = os.path.dirname(args.oe_build_env)
-            logging.warning("Fixing OE environment name (--oe_build_env) which was specified as a PATH")
-        global_values.oe_build_env = os.path.basename(args.oe_build_env)
 
     if args.testmode:
         global_values.testmode = True

--- a/bd_scan_yocto/global_values.py
+++ b/bd_scan_yocto/global_values.py
@@ -18,6 +18,7 @@ bd_version = ''
 # offline = False
 oe_build_env = ''
 oe_build_envpath = '.'
+oe_build_envfile = ''
 deploy_dir = ''
 download_dir = ''
 pkg_dir = ''


### PR DESCRIPTION
Detect expects that the bitbake.build.env.name is relative to source.path.