### PR TITLE
Resolve conflict between BD verify setting and connection in config.py

### DIFF
--- a/bd_scan_yocto/bd_process_bom.py
+++ b/bd_scan_yocto/bd_process_bom.py
@@ -95,7 +95,7 @@ def process_bdproject(bdproj, bdver):
 	bd = Client(
 		token=global_values.bd_api,
 		base_url=global_values.bd_url,
-		verify=(not global_values.bd_trustcert),  # TLS certificate verification
+		verify=global_values.bd_trustcert,  # TLS certificate verification
 		timeout=60
 	)
 


### PR DESCRIPTION
The BD verify setting in the file was conflicting with the connection made in config.py (line 264), causing one of the connections to fail due to opposing configurations. This commit corrects the issue to ensure both settings work harmoniously.